### PR TITLE
mon: use HostPathDirectoryOrCreate for host path volume ceph-mon-data

### DIFF
--- a/pkg/operator/ceph/controller/spec.go
+++ b/pkg/operator/ceph/controller/spec.go
@@ -286,7 +286,8 @@ func DaemonVolumesDataHostPath(dataPaths *config.DataPathMap) []v1.Volume {
 	src := v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}
 	if dataPaths.HostDataDir != "" {
 		// data is persisted to host
-		src = v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: dataPaths.HostDataDir}}
+		hostPathType := v1.HostPathDirectoryOrCreate
+		src = v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: dataPaths.HostDataDir, Type: &hostPathType}}
 	}
 	return append(vols, v1.Volume{Name: "ceph-daemon-data", VolumeSource: src})
 }


### PR DESCRIPTION
As the volume folder does not exist on the node where, there is no create if not exist workflow without the flag `DirectoryOrCreate`.

Fixes: https://github.com/rook/rook/issues/14251

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
